### PR TITLE
Added auto connect after turning on controller

### DIFF
--- a/BluetoothPS2Controller.ino
+++ b/BluetoothPS2Controller.ino
@@ -59,6 +59,12 @@ void setup()
 	{
 		gamepadInitialized = true;
 	}
+
+	delay(400);
+	Serial.print("$$$"); //to enter command mode 
+	delay(100);
+	Serial.println("C"); //Connect to stored remote address
+	delay(50);
 }
 
 void loop()


### PR DESCRIPTION
I have added auto reconnecting after turning on gamepad.
I did it using command mode, and one command from this [document](https://cdn.sparkfun.com/datasheets/Wireless/Bluetooth/bluetooth_cr_UG-v1.0r.pdf).
